### PR TITLE
Fix anchor in the link for URL copying

### DIFF
--- a/src/Section.js
+++ b/src/Section.js
@@ -338,7 +338,7 @@ export default class Section {
           func: this.copyLink.bind(this),
           class: 'copySectionLink',
           tooltip: 'Нажмите, чтобы скопировать вики-ссылку. Нажмите с зажатым Ctrl, чтобы выбрать другой вид ссылки.',
-          href: mw.util.getUrl(cd.env.CURRENT_PAGE) + '#' + this.heading,
+          href: mw.util.getUrl(cd.env.CURRENT_PAGE) + '#' + this.heading.replace(/ /g, '_'),
         });
       });
     }


### PR DESCRIPTION
Currently, anchors are invalid. This fixes it the same way it’s done in another part of the code.