### PR TITLE
Update messages to avoid lego form

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,15 +1,15 @@
 {
   "script-name": "Convenient Discussions",
-  "script-name-genitive": "{{int:convenientdiscussions-script-name}}",
-  "script-name-prepositional": "{{int:convenientdiscussions-script-name}}",
+  "script-name-genitive": "Convenient Discussions",
+  "script-name-prepositional": "Convenient Discussions",
   "script-name-short": "CD",
 
-  "user-male-dative": "",
-  "user-male-genitive": "",
-  "user-female-dative": "",
-  "user-female-genitive": "",
-  "user-unknown-dative": "",
-  "user-unknown-genitive": "",
+  "user-male-dative": "user",
+  "user-male-genitive": "user",
+  "user-female-dative": "user",
+  "user-female-genitive": "user",
+  "user-unknown-dative": "user",
+  "user-unknown-genitive": "user",
 
   "cm-gotoparent": "▲",
   "cm-gotoparent-tooltip": "Go to the parent comment",
@@ -81,7 +81,7 @@
 
   "es-reply": "reply",
   "es-reply-genitive": "the reply",
-  "es-reply-by-genitive": "{{int:convenientdiscussions-es-reply-genitive}} by $1",
+  "es-reply-by-genitive": "the reply by $1",
   "es-addition": "addition",
   "es-addition-genitive": "addition",
   "es-delete": "delete",
@@ -91,14 +91,14 @@
   "es-topic-openingcomment-genitive": "the opening comment",
   "es-subsection-openingcomment-genitive": "the opening comment",
   "es-comment-genitive": "the comment",
-  "es-comment-by-genitive": "{{int:convenientdiscussions-es-comment-genitive}} by $1",
+  "es-comment-by-genitive": "the comment by $1",
   "es-new-topic": "new topic",
   "es-new-subsection": "new subsection",
   "es-to": "to",
   "es-move": "move",
-  "es-move-from": "{{int:convenientdiscussions-es-moved}} from [[$1]]",
-  "es-move-to": "{{int:convenientdiscussions-es-moved}} to [[$1]]",
-  "es-reply-to": "{{int:convenientdiscussions-es-reply}} {{int:convenientdiscussions-es-to}} $1",
+  "es-move-from": "move from [[$1]]",
+  "es-move-to": "move to [[$1]]",
+  "es-reply-to": "the reply to $1",
   "es-action-to": "$1 $2",
 
   "cf-headline": "Subject/headline",
@@ -130,7 +130,7 @@
   "cf-cancel": "Cancel",
   "cf-cancel-short": "Cancel",
   "cf-settings": "Settings",
-  "cf-settings-tooltip": "{{int:convenientdiscussions-script-name}} settings",
+  "cf-settings-tooltip": "Convenient Discussions settings",
   "cf-help": "?",
   "cf-help-short": "?",
   "cf-help-content": "<p><a href=\"https://www.mediawiki.org/wiki/User:Jack_who_built_the_house/Convenient_Discussions\" target=\"_blank\">Script documentation</a></p>\n<p>Hotkeys:</p>\n<ul>\n<li><b>Ctrl+Enter</b> — post</li>\n<li><b>Esc</b> — cancel</li>\n<li><b>Q</b> (<b>Ctrl+Alt+Q</b>) — quote</li>\n</ul>",
@@ -190,7 +190,7 @@
   "cf-confirm-close-yes": "Close",
   "cf-confirm-close-no": "Cancel",
 
-  "dn-confirm": "Do you want {{int:convenientdiscussions-script-name}} to send you desktop notifications about new comments on currently open pages if they are addressed to you or posted in sections that you watch? You can disable this feature in the settings.",
+  "dn-confirm": "Do you want Convenient Discussions to send you desktop notifications about new comments on currently open pages if they are addressed to you or posted in sections that you watch? You can disable this feature in the settings.",
   "dn-confirm-yes": "Yes",
   "dn-confirm-no": "No",
   "dn-grantpermission": "Grant a permission to the site.",
@@ -233,7 +233,7 @@
   "notification-part-insection": "in section \"$1\"",
   "notification-part-onthispage": "on this page",
 
-  "sd-title": "{{int:convenientdiscussions-script-name}} settings",
+  "sd-title": "Convenient Discussions settings",
   "sd-save": "Save",
   "sd-reload": "Reload",
   "sd-page-talkpage": "Talk page",
@@ -247,7 +247,7 @@
   "sd-reset": "Reset settings (in all sections)",
   "sd-reset-confirm": "Are you sure you want to reset the settings? (Click \"{{int:convenientdiscussions-sd-save}}\" after resetting.)",
   "sd-removedata": "Remove all script data",
-  "sd-removedata-description": "Delete the data that {{int:convenientdiscussions-script-name}} has collected: your settings, talk page last visits, watched sections, and drafts of unsent comments",
+  "sd-removedata-description": "Delete the data that Convenient Discussions has collected: your settings, talk page last visits, watched sections, and drafts of unsent comments",
   "sd-removedata-help": "See <a href=\"https://www.mediawiki.org/wiki/User:Jack_who_built_the_house/Convenient_Discussions#Data\" target=\"_blank\">the script homepage</a> for the instructions on how to delete each piece of data individually.",
   "sd-removedata-confirm": "This will permanently delete your settings, talk page last visits, watched sections, and drafts of unsent comments. Do you want to proceed?",
   "sd-removedata-confirm-yes": "Yes",
@@ -331,7 +331,7 @@
 
   "wl-button-switchinteresting-tooltip": "Show only comments in sections that I watch and comments addressed to me",
   "wl-button-editwatchedsections-tooltip": "Edit sections that I watch",
-  "wl-button-scriptsettings-tooltip": "{{int:convenientdiscussions-script-name}} settings",
+  "wl-button-scriptsettings-tooltip": "Convenient Discussions settings",
 
   "lp-comment": "comment",
   "lp-comment-tooltip": "Go to comment",
@@ -339,5 +339,5 @@
   "lp-comment-watchedsection": "you are watching this section",
 
   "loading-ellipsis": "Loading…",
-  "addtopicbutton-tooltip": "Open in a new tab to create a new topic on a standard page, not in {{int:convenientdiscussions-script-name-prepositional}}."
+  "addtopicbutton-tooltip": "Open in a new tab to create a new topic on a standard page, not in Convenient Discussions."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,12 +4,12 @@
   "script-name-prepositional": "Convenient Discussions",
   "script-name-short": "CD",
 
-  "user-male-dative": "user",
-  "user-male-genitive": "user",
-  "user-female-dative": "user",
-  "user-female-genitive": "user",
-  "user-unknown-dative": "user",
-  "user-unknown-genitive": "user",
+  "user-male-dative": "",
+  "user-male-genitive": "",
+  "user-female-dative": "",
+  "user-female-genitive": "",
+  "user-unknown-dative": "",
+  "user-unknown-genitive": "",
 
   "cm-gotoparent": "▲",
   "cm-gotoparent-tooltip": "Go to the parent comment",
@@ -98,7 +98,7 @@
   "es-move": "move",
   "es-move-from": "move from [[$1]]",
   "es-move-to": "move to [[$1]]",
-  "es-reply-to": "the reply to $1",
+  "es-reply-to": "reply to $1",
   "es-action-to": "$1 $2",
 
   "cf-headline": "Subject/headline",


### PR DESCRIPTION
Following the requirements in https://translatewiki.net/wiki/Setup_of_a_new_project#Verify_the_project remove the lego form from some messages