### PR TITLE
w-en.js: whitelist FAC, PR, DYK and BRFA discussion pages

### DIFF
--- a/config/w-en.js
+++ b/config/w-en.js
@@ -69,10 +69,7 @@ export default {
   ],
 
   pageWhitelist: [
-    /^Wikipedia:Feature article candidates\//,
-    /^Wikipedia:Peer review\//,
     /^Template:Did you know nominations\//,
-    /^Wikipedia:Bots\/Requests for approval\//
   ],
 
   spaceAfterIndentationChars: false,

--- a/config/w-en.js
+++ b/config/w-en.js
@@ -68,6 +68,13 @@ export default {
     /\/Archive/,
   ],
 
+  pageWhitelist: [
+    /^Wikipedia:Feature article candidates\//,
+    /^Wikipedia:Peer review\//,
+    /^Template:Did you know nominations\//,
+    /^Wikipedia:Bots\/Requests for approval\//
+  ],
+
   spaceAfterIndentationChars: false,
 
   signatureEndingRegexp: / \(talk\)/,

--- a/config/w-en.js
+++ b/config/w-en.js
@@ -69,6 +69,8 @@ export default {
   ],
 
   pageWhitelist: [
+    /^Wikipedia:/,
+    /^Help:/,
     /^Template:Did you know nominations\//,
   ],
 


### PR DESCRIPTION
Sample pages to test on:
- [Wikipedia:Featured article candidates/Ted Kaczynski/archive1](https://en.wikipedia.org/wiki/Wikipedia:Featured_article_candidates/Ted_Kaczynski/archive1)
- [Wikipedia:Peer review/Kronstadt rebellion/archive1](https://en.wikipedia.org/wiki/Wikipedia:Peer_review/Kronstadt_rebellion/archive1)
- [Template:Did you know nominations/Azari or the Ancient Language of Azerbaijan](https://en.wikipedia.org/wiki/Template:Did_you_know_nominations/Azari_or_the_Ancient_Language_of_Azerbaijan)
- [Wikipedia:Bots/Requests for approval/SDZeroBot 9](https://en.wikipedia.org/wiki/Wikipedia:Bots/Requests_for_approval/SDZeroBot_9)

Note that in case of FAC and PR, active nominations are discussed on pages already having "/archive" in title.

I'm not sure if [WP:RFA](https://en.wikipedia.org/wiki/Wikipedia:Requests_for_adminship) or WP:RFB pages also need to be whitelisted (no active nominations as of now to check with).