### PR TITLE
w-en: add archivePaths config for enwiki admin boards

### DIFF
--- a/config/w-en.js
+++ b/config/w-en.js
@@ -65,6 +65,14 @@ export default {
   localTimezoneOffset: 0,
 
   archivePaths: [
+    {
+      source: "Wikipedia:Administrators' noticeboard/Incidents",
+      archive: "Wikipedia:Administrators' noticeboard/IncidentArchive"
+    },
+    {
+      source: "Wikipedia:Administrators' noticeboard/Edit warring",
+      archive: "Wikipedia:Administrators' noticeboard/3RRArchive"
+    },
     /\/Archive/,
   ],
 

--- a/config/w-en.js
+++ b/config/w-en.js
@@ -67,11 +67,11 @@ export default {
   archivePaths: [
     {
       source: "Wikipedia:Administrators' noticeboard/Incidents",
-      archive: "Wikipedia:Administrators' noticeboard/IncidentArchive"
+      archive: "Wikipedia:Administrators' noticeboard/IncidentArchive",
     },
     {
       source: "Wikipedia:Administrators' noticeboard/Edit warring",
-      archive: "Wikipedia:Administrators' noticeboard/3RRArchive"
+      archive: "Wikipedia:Administrators' noticeboard/3RRArchive",
     },
     /\/Archive/,
   ],


### PR DESCRIPTION
These pages have an unusual archive page naming pattern