### PR TITLE
commentLinks: don't throw on empty contributions pages

### DIFF
--- a/src/js/commentLinks.js
+++ b/src/js/commentLinks.js
@@ -425,15 +425,25 @@ function processWatchlist($content) {
 }
 
 /**
+ * Returns the timezone per user preferences
+ *
+ * @returns {number} timezone offset in minutes
+ * @private
+ */
+function getUserTimezoneOffset() {
+  const timezone = mw.user.options.get('timecorrection');
+  const timezoneParts = timezone?.split('|');
+  return timezoneParts && Number(timezoneParts[1]);
+}
+
+/**
  * Add comment links to a contributions page.
  *
  * @param {JQuery} $content
  * @private
  */
 function processContributions($content) {
-  const timezone = mw.user.options.get('timecorrection');
-  const timezoneParts = timezone?.split('|');
-  const timezoneOffset = timezoneParts && Number(timezoneParts[1]);
+  const timezoneOffset = getUserTimezoneOffset();
   if (timezoneOffset == null || isNaN(timezoneOffset)) return;
 
   const list = $content.get(0).querySelector('.mw-contributions-list');
@@ -500,9 +510,7 @@ function processContributions($content) {
  * @private
  */
 function processHistory($content) {
-  const timezone = mw.user.options.get('timecorrection');
-  const timezoneParts = timezone?.split('|');
-  const timezoneOffset = timezoneParts && Number(timezoneParts[1]);
+  const timezoneOffset = getUserTimezoneOffset();
   if (timezoneOffset == null || isNaN(timezoneOffset)) return;
 
   const list = $content.get(0).querySelector('#pagehistory');
@@ -584,9 +592,7 @@ function processHistory($content) {
 async function processDiff() {
   if (!processDiffFirstRun) return;
 
-  const timezone = mw.user.options.get('timecorrection');
-  const timezoneParts = timezone?.split('|');
-  const timezoneOffset = timezoneParts && Number(timezoneParts[1]);
+  const timezoneOffset = getUserTimezoneOffset();
   if (timezoneOffset == null || isNaN(timezoneOffset)) return;
 
   [document.querySelector('.diff-otitle'), document.querySelector('.diff-ntitle')]

--- a/src/js/commentLinks.js
+++ b/src/js/commentLinks.js
@@ -437,6 +437,9 @@ function processContributions($content) {
   if (timezoneOffset == null || isNaN(timezoneOffset)) return;
 
   const list = $content.get(0).querySelector('.mw-contributions-list');
+  if (!list) { // empty contributions list
+    return;
+  }
   const lines = Array.from(list.children);
 
   lines.forEach((line) => {


### PR DESCRIPTION
Eg. https://en.wikipedia.org/wiki/Special:Contributions/SD0002 which presently causes `Uncaught (in promise) TypeError: Cannot read property 'children' of null`

2nd commit: Pull duplicated code for getting user timezone into a function.

But I think there is an issue with this way of getting the user timezone. It does not take into account changes due to DST. See https://phabricator.wikimedia.org/T223002. I believe there's no way in JS to retrieve the DST-corrected timezone offset, unfortunately :(