### PR TITLE
avoid dependency on VisualEditor

### DIFF
--- a/src/js/siteData.js
+++ b/src/js/siteData.js
@@ -502,7 +502,7 @@ const TIMEZONES = [
 function setFormats() {
   let langCode = mw.config.get('wgPageContentLanguage');
   if (!DATE_FORMATS[langCode]) {
-    langCode = mw.config.get('wgVisualEditor').pageVariantFallbacks;
+    langCode = mw.config.get('wgVisualEditor')?.pageVariantFallbacks;
     if (!DATE_FORMATS[langCode]) {
       // https://incubator.wikimedia.org/wiki/Talk:Wp/enm/Mayne_Page
       langCode = mw.config.get('wgContentLanguage');


### PR DESCRIPTION
mw.config.get('wgVisualEditor').pageVariantFallbacks will cause an error on wikis without VisualEditor