### PR TITLE
fix makeBackgroundRequest and setGlobalOption

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -35,6 +35,15 @@ export default {
   localTimezoneOffset: null,
 
   /**
+   * Whether to store of the some of the preferences globally. Requires Extension:GlobalPreferences to
+   * be enabled.
+   *
+   * @type {?boolean}
+   * @default true
+   */
+  useGlobalPreferences: true,
+
+  /**
    * Numbers of talk namespaces other than odd namespaces. If not set, the value of
    * `mw.config.get('wgExtraSignatureNamespaces')` will be used. For example: `[4]` for Project.
    *

--- a/misc/convenientDiscussions-generateBasicConfig.js
+++ b/misc/convenientDiscussions-generateBasicConfig.js
@@ -47,7 +47,7 @@ mw.loader.using([
   const siteInfoResp = await api.get({
     action: 'query',
     meta: 'siteinfo',
-    siprop: ['specialpagealiases', 'general'],
+    siprop: ['specialpagealiases', 'general', 'extensions'],
   });
   siteInfoResp.query.specialpagealiases.some((alias) => {
     if (alias.realname === 'Contributions') {
@@ -56,6 +56,7 @@ mw.loader.using([
     }
   });
   config.localTimezoneOffset = siteInfoResp.query.general.timeoffset;
+  config.useGlobalPreferences = !!siteInfoResp.query.extensions.find(e => e.name === 'GlobalPreferences');
 
   const idsToProps = {
     Q5573785: 'unsigned',

--- a/src/js/apiWrappers.js
+++ b/src/js/apiWrappers.js
@@ -32,13 +32,13 @@ export function makeBackgroundRequest(params, method = 'post') {
     cd.g.api[method](params, {
       success: (resp) => {
         if (resp.error) {
-          reject('api', resp);
+          reject(['api', resp]);
         } else {
           resolve(resp);
         }
       },
       error: (jqXHR, textStatus) => {
-        reject('http', textStatus);
+        reject(['http', textStatus]);
       },
     });
   });

--- a/src/js/apiWrappers.js
+++ b/src/js/apiWrappers.js
@@ -310,6 +310,9 @@ export async function setLocalOption(name, value) {
  * @throws {CdError}
  */
 export async function setGlobalOption(name, value) {
+  if (!cd.config.useGlobalPreferences) {
+    return;
+  }
   try {
     await setOption(name, value, 'globalpreferences');
   } catch (e) {

--- a/src/js/apiWrappers.js
+++ b/src/js/apiWrappers.js
@@ -310,7 +310,16 @@ export async function setLocalOption(name, value) {
  * @throws {CdError}
  */
 export async function setGlobalOption(name, value) {
-  await setOption(name, value, 'globalpreferences');
+  try {
+    await setOption(name, value, 'globalpreferences');
+  } catch (e) {
+    // The site doesn't support global preferences.
+    if (e instanceof CdError && e.data.apiData && e.data.apiData.error.code === 'badvalue') {
+      await setLocalOption(name, value);
+    } else {
+      throw e;
+    }
+  }
 }
 
 /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -185,19 +185,10 @@ export async function setSettings(settings) {
     }
   });
 
-  try {
-    await Promise.all([
-      setLocalOption(cd.g.LOCAL_SETTINGS_OPTION_NAME, JSON.stringify(localSettings)),
-      setGlobalOption(cd.g.SETTINGS_OPTION_NAME, JSON.stringify(globalSettings))
-    ]);
-  } catch (e) {
-    // The site doesn't support global preferences.
-    if (e instanceof CdError && e.data.apiData && e.data.apiData.error.code === 'badvalue') {
-      await setLocalOption(cd.g.SETTINGS_OPTION_NAME, JSON.stringify(globalSettings));
-    } else {
-      throw e;
-    }
-  }
+  await Promise.all([
+    setLocalOption(cd.g.LOCAL_SETTINGS_OPTION_NAME, JSON.stringify(localSettings)),
+    setGlobalOption(cd.g.SETTINGS_OPTION_NAME, JSON.stringify(globalSettings))
+  ]);
 }
 
 /**

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -189,11 +189,15 @@ export function flat(arr) {
 /**
  * Callback used in the `.catch()` parts of `mw.Api` requests.
  *
- * @param {string} code
+ * @param {string|Array} code
  * @param {object} data
  * @throws {CdError}
  */
 export function handleApiReject(code, data) {
+  // Native promises support only one parameter.
+  if (Array.isArray(code)) {
+    [code, data] = code;
+  }
   // See the parameters with which mw.Api() rejects:
   // https://phabricator.wikimedia.org/source/mediawiki/browse/master/resources/src/mediawiki.api/index.js;fbfa8f1a61c5ffba664e817701439affb4f6a388$245
   throw code === 'http' ?


### PR DESCRIPTION
fix makeBackgroundRequest and setGlobalOption to solve the issue described in https://github.com/jwbth/convenient-discussions/pull/27#issuecomment-813491930. Also fixes the issue of "Remove all script data" option wrongly showing an error on wikis without GlobalPreferences. 