### PR TITLE
add option to make comments show in local time

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -276,6 +276,7 @@
   "sd-insertbuttons": "Text insert buttons",
   "sd-insertbuttons-multiselect-placeholder": "Add a button",
   "sd-insertbuttons-help": "Use <code>+</code> to specify a place where the caret should be put after inserting the text; for example, <code><nowiki>{{+}}</nowiki></code>. Use <code>;</code> to specify displayed text if you want it to be different from the one inserted; for example, <code><nowiki><code>+</code>;<code /></nowiki></code>. Use <code><nowiki>\\</nowiki></code> before the aforementioned characters to insert them as is; for example, <code><nowiki>2\\+2</nowiki></code>. The buttons can be dragged and dropped.",
+  "sd-localtimecomments": "Show comment timestamps in my system time zone",
   "sd-notifications": "Ordinary notifications",
   "sd-notifications-radio-all": "Notify me about replies to my comments and comments in sections that I watch",
   "sd-notifications-radio-tome": "Notify me about replies to my comments only",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -259,6 +259,7 @@
 	"sd-insertbuttons": "Label of the [https://doc.wikimedia.org/oojs-ui/master/demos/?page=widgets&theme=wikimediaui&direction=ltr&platform=desktop#demo-section-tagMultiselect tag multiselect input] in the settings dialog.",
 	"sd-insertbuttons-multiselect-placeholder": "Placeholder of the tag multiselect input labeled with the {{msg-wm|Convenient-discussions-sd-insertbuttons}} message in the settings dialog.",
 	"sd-insertbuttons-help": "Help text for the tag multiselect input labeled with the {{msg-wm|Convenient-discussions-sd-insertbuttons}} message in the settings dialog.\n\nThis text explains the feature that works in a similar way to [[mw:MediaWiki:Edittools]] (the <nowiki><charinsert></nowiki> tag).",
+	"sd-localtimecomments": "Label of the checkbox in the settings dialog",
 	"sd-notifications": "Label of the radio select in the settings dialog.",
 	"sd-notifications-radio-all": "Label of the item of the radio select labeled with the {{msg-wm|Convenient-discussions-sd-notifications}} message in the settings dialog.",
 	"sd-notifications-radio-tome": "Label of the item of the radio select labeled with the {{msg-wm|Convenient-discussions-sd-notifications}} message in the settings dialog.",

--- a/src/js/Comment.js
+++ b/src/js/Comment.js
@@ -38,6 +38,7 @@ import {
 } from './wikitext';
 import { getUserGenders, parseCode } from './apiWrappers';
 import { reloadPage } from './boot';
+import {formatDate} from "./timestamp";
 
 let thanks;
 
@@ -122,6 +123,8 @@ export default class Comment extends CommentSkeleton {
      * @type {JQuery}
      */
     this.$timestamp = $(signature.timestampElement);
+
+    this.localizeTimestamp();
 
     /**
      * Is the comment actionable, i.e. you can reply to or edit it. A comment is actionable if it is
@@ -231,6 +234,23 @@ export default class Comment extends CommentSkeleton {
         }
       }
     }
+  }
+
+  /**
+   * Turn the timestamp in comments to the user's local time. The original timestamp is
+   * retained in the title attribute, displayed as a tooltip on hover.
+   */
+  localizeTimestamp() {
+    if (!cd.settings.localTimeComments) {
+      return;
+    }
+    let modifiedDate = new Date(this.date.getTime());
+    modifiedDate.setMinutes(modifiedDate.getMinutes() - modifiedDate.getTimezoneOffset());
+    let localTs = formatDate(modifiedDate);
+    let offset = this.date.getTimezoneOffset() / 60; // not necessarily an integer
+    let sign = offset > 0 ? '-' : '+';
+    this.$timestamp.attr('title', this.$timestamp.text());
+    this.$timestamp.text(localTs + ` (UTC${sign}${Math.abs(offset)})`);
   }
 
   /**

--- a/src/js/boot.js
+++ b/src/js/boot.js
@@ -88,6 +88,7 @@ export async function initSettings() {
     defaultCommentLinkType: null,
     defaultSectionLinkType: null,
     highlightOwnComments: true,
+    localTimeComments: false,
     insertButtons: cd.config.defaultInsertButtons || [],
     notifications: 'all',
     notificationsBlacklist: [],

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -416,6 +416,12 @@ export async function settingsDialog() {
       label: cd.s('sd-highlightowncomments'),
     });
 
+    [this.localTimeCommentsField, this.localTimeCommentsCheckbox] = checkboxField({
+      value: 'localTimeComments',
+      selected: settings.localTimeComments,
+      label: cd.s('sd-localtimecomments')
+    });
+
     const insertButtonsSelected = settings.insertButtons
       .map((button) => Array.isArray(button) ? button.join(';') : button);
     this.insertButtonsMultiselect = new OO.ui.TagMultiselectWidget({
@@ -531,6 +537,7 @@ export async function settingsDialog() {
       choose: 'changeDesktopNotifications',
     });
     this.highlightOwnCommentsCheckbox.connect(this, { change: 'updateStates' });
+    this.localTimeCommentsCheckbox.connect(this, { change: 'updateStates' });
     this.modifyTocCheckbox.connect(this, { change: 'updateStates' });
     this.notificationsSelect.connect(this, { select: 'updateStates' });
     this.notificationsBlacklistMultiselect.connect(this, { change: 'updateStates' });
@@ -566,6 +573,7 @@ export async function settingsDialog() {
       GeneralPageLayout.super.call(this, name, config);
       this.$element.append([
         dialog.highlightOwnCommentsField.$element,
+        dialog.localTimeCommentsField.$element,
         dialog.useBackgroundHighlightingField.$element,
         dialog.allowEditOthersCommentsField.$element,
         dialog.modifyTocField.$element,
@@ -668,6 +676,7 @@ export async function settingsDialog() {
         'unknown'
       ),
       highlightOwnComments: this.highlightOwnCommentsCheckbox.isSelected(),
+      localTimeComments: this.localTimeCommentsCheckbox.isSelected(),
       insertButtons: this.processInsertButtons(),
       modifyToc: this.modifyTocCheckbox.isSelected(),
       notifications: this.notificationsSelect.findSelectedItem()?.getData(),


### PR DESCRIPTION
Because this is another thing that makes discussions convenient.

Turned off by default because many wikis have a gadget that does that could conflict. Though I guess we could discuss making this default-on.