### PR TITLE
Speed up script fetches from config by using caching

### DIFF
--- a/buildConfigs.js
+++ b/buildConfigs.js
@@ -33,6 +33,16 @@ function unique(item, i, arr) {
   return arr.indexOf(item) === i;
 }
 
+function getCommonsScript(page) {
+  return $.get(
+    'https://commons.wikimedia.org/w/api.php?titles=' + encodeURIComponent(page) +
+    '&origin=*&uselang=content&maxage=86400&smaxage=86400&format=json&formatversion=2' +
+    '&action=query&prop=revisions&rvprop=content&rvlimit=1'
+  ).then(function(apiResponse) {
+    eval(apiResponse.query.pages[0].revisions[0].content);
+  });
+}
+
 function getStrings() {
   const requests = [mw.config.get('wgUserLanguage'), mw.config.get('wgContentLanguage')]
     .filter(unique)
@@ -40,7 +50,7 @@ function getStrings() {
       return lang !== 'en';
     })
     .map(function (lang) {
-      return mw.loader.getScript('https://commons.wikimedia.org/w/index.php?title=User:Jack_who_built_the_house/convenientDiscussions-i18n/' + lang + '.js&action=raw&ctype=text/javascript');
+      return getCommonsScript('User:Jack_who_built_the_house/convenientDiscussions-i18n/' + lang + '.js');
     });
 
   // We assume it's OK to fall back to English if the translation is unavailable for any reason.
@@ -60,7 +70,7 @@ convenientDiscussions.config = ${content}
 
 if (!convenientDiscussions.isRunning) {
   convenientDiscussions.getStringsPromise = getStrings();
-  mw.loader.getScript('https://commons.wikimedia.org/w/index.php?title=User:Jack_who_built_the_house/convenientDiscussions${testSuffix}.js&action=raw&ctype=text/javascript')
+  getCommonsScript('User:Jack_who_built_the_house/convenientDiscussions${testSuffix}.js')
     .catch(function (e) {
       console.warn('Couldn\\'t load Convenient Discussions.', e);
     });

--- a/misc/convenientDiscussions-generateBasicConfig.js
+++ b/misc/convenientDiscussions-generateBasicConfig.js
@@ -194,6 +194,16 @@ function unique(item, i, arr) {
   return arr.indexOf(item) === i;
 }
 
+function getCommonsScript(page) {
+  return $.get(
+    'https://commons.wikimedia.org/w/api.php?titles=' + encodeURIComponent(page) +
+    '&origin=*&uselang=content&maxage=86400&smaxage=86400&format=json&formatversion=2' +
+    '&action=query&prop=revisions&rvprop=content&rvlimit=1'
+  ).then(function(apiResponse) {
+    eval(apiResponse.query.pages[0].revisions[0].content);
+  });
+}
+
 function getStrings() {
   const requests = [mw.config.get('wgUserLanguage'), mw.config.get('wgContentLanguage')]
     .filter(unique)
@@ -201,7 +211,7 @@ function getStrings() {
       return lang !== 'en';
     })
     .map(function (lang) {
-      return mw.loader.getScript('https://commons.wikimedia.org/w/index.php?title=User:Jack_who_built_the_house/convenientDiscussions-i18n/' + lang + '.js&action=raw&ctype=text/javascript');
+      return getCommonsScript('User:Jack_who_built_the_house/convenientDiscussions-i18n/' + lang + '.js');
     });
 
   // We assume it's OK to fall back to English if the translation is unavailable for any reason.
@@ -221,7 +231,7 @@ convenientDiscussions.config = ${output};
 
 if (!convenientDiscussions.isRunning) {
   convenientDiscussions.getStringsPromise = getStrings();
-  mw.loader.getScript('https://commons.wikimedia.org/w/index.php?title=User:Jack_who_built_the_house/convenientDiscussions.js&action=raw&ctype=text/javascript')
+  getCommonsScript('User:Jack_who_built_the_house/convenientDiscussions.js')
     .catch(function (e) {
       console.warn('Couldn\\'t load Convenient Discussions.', e);
     });


### PR DESCRIPTION
A normal `mw.loader.getScript` or `mw.loader.load` or `importScript` call results in a response with Cache-Control header 
```
private, s-maxage=0, max-age=0, must-revalidate
```
With the getCommonsScript function added here, the Cache-Control header is 
```
s-maxage=86400, max-age=86400, public
```

At least on my system, the latter causes most requests to be resolved by disk cache itself which is 100x faster. (I've been experimenting with a [modified importScript definition for loading user scripts](https://en.wikipedia.org/wiki/User:SD0001/common.js#L-5))

This could also be used in app.js for fetching config and i18n. 

----

* `uselang=content` enables public caching (https://phabricator.wikimedia.org/T97096) [though this may not work for users with admin right, but private caching will still work]. 
* `origin=*` prevent CORS issue. 

