### PR TITLE
Enable post-save transform in view changes

### DIFF
--- a/src/js/CommentForm.js
+++ b/src/js/CommentForm.js
@@ -2942,6 +2942,7 @@ export default class CommentForm {
     try {
       const options = {
         action: 'compare',
+        totitle: this.targetPage.name,
         toslots: 'main',
         'totext-main': code,
         topst: true,

--- a/src/js/CommentForm.js
+++ b/src/js/CommentForm.js
@@ -2944,6 +2944,7 @@ export default class CommentForm {
         action: 'compare',
         toslots: 'main',
         'totext-main': code,
+        topst: true,
         prop: 'diff',
         formatversion: 2,
       };


### PR DESCRIPTION
This makes substituted templates and signatures render in "view changes" mode. MediaWiki's "view changes" also does this.