### PR TITLE
Removing classes from configurations that have been replaced by native ones

### DIFF
--- a/config/s-ru.js
+++ b/config/s-ru.js
@@ -171,8 +171,11 @@ export default {
   ],
 
   elementsToExcludeClasses: [
+    'ruwiki-movedTemplate',
     'ambox',
     'NavHead',
+    'ts-Закрыто-footer',
+    'ts-Цитата-container',
   ],
 
   templatesToExclude: [
@@ -225,11 +228,18 @@ export default {
   ],
 
   closedDiscussionClasses: [
+    'ruwiki-closedDiscussion',
     'NavContent',
   ],
 
   customUnhighlightableElementClasses: [
     'infobox',
+    'ruwiki-movedTemplate',
+  ],
+
+  customAddTopicLinkSelectors: [
+    '.ruwiki-addTopicLink a',
+    '.ruwiki-addSectionBottom',
   ],
 
   noConfirmPostEmptyCommentPageRegexp: /^(?:Викитека:Заявки на статус |Викитека:Голосования\/)/,

--- a/config/s-ru.js
+++ b/config/s-ru.js
@@ -171,11 +171,8 @@ export default {
   ],
 
   elementsToExcludeClasses: [
-    'ruwiki-movedTemplate',
     'ambox',
     'NavHead',
-    'ts-Закрыто-footer',
-    'ts-Цитата-container',
   ],
 
   templatesToExclude: [
@@ -228,18 +225,11 @@ export default {
   ],
 
   closedDiscussionClasses: [
-    'ruwiki-closedDiscussion',
     'NavContent',
   ],
 
   customUnhighlightableElementClasses: [
     'infobox',
-    'ruwiki-movedTemplate',
-  ],
-
-  customAddTopicLinkSelectors: [
-    '.ruwiki-addTopicLink a',
-    '.ruwiki-addSectionBottom',
   ],
 
   noConfirmPostEmptyCommentPageRegexp: /^(?:Викитека:Заявки на статус |Викитека:Голосования\/)/,

--- a/config/w-en.js
+++ b/config/w-en.js
@@ -211,7 +211,6 @@ export default {
   },
 
   elementsToExcludeClasses: [
-    'cd-moveMark',
     'unresolved',
     'resolved',
     'ambox',

--- a/config/w-fr.js
+++ b/config/w-fr.js
@@ -123,7 +123,6 @@ export default {
 		'Clear'
 	],
   elementsToExcludeClasses: [
-    'cd-moveMark',
     'NavFrame',
   ],
 	'signatureEndingRegexp': / \(discuter\)/

--- a/config/w-ru.js
+++ b/config/w-ru.js
@@ -338,12 +338,6 @@ export default {
 
   customUnhighlightableElementClasses: [
     'infobox',
-    'ruwiki-movedTemplate',
-  ],
-
-  customAddTopicLinkSelectors: [
-    '.ruwiki-addTopicLink a',
-    '.ruwiki-addSectionBottom',
   ],
 
   noConfirmPostEmptyCommentPageRegexp: /^(?:Википедия:Заявки на статус |Википедия:Голосования\/)/,

--- a/config/w-ru.js
+++ b/config/w-ru.js
@@ -270,13 +270,9 @@ export default {
   ],
 
   elementsToExcludeClasses: [
-    'ruwiki-movedTemplate',
     'ambox',
     'NavHead',
-    'ts-Закрыто-footer',
-    'ts-Цитата-container',
     'raaf',
-    'ts-Скрытие_текста_реплик',
   ],
 
   templatesToExclude: [
@@ -337,7 +333,6 @@ export default {
   ],
 
   closedDiscussionClasses: [
-    'ruwiki-closedDiscussion',
     'NavContent',
   ],
 


### PR DESCRIPTION
closedDiscussionClasses uses .mw-notalk class
elementsToExcludeClasses uses .mw-archivedtalk class
customAddTopicLinkSelectors uses .cd-addTopicButton class