### PR TITLE
fix invisible side boxes (closer summaries) under dark mode

### DIFF
--- a/src/Comment.layers.less
+++ b/src/Comment.layers.less
@@ -37,12 +37,20 @@
 @media screen {
   html.skin-theme-clientpref-night {
     .darkTheme-commentVars();
+
+    .side-box .cd-commentLayersContainer {
+      background: initial !important;
+    }
   }
 }
 
 @media screen and (prefers-color-scheme: dark) {
   html.skin-theme-clientpref-os {
     .darkTheme-commentVars();
+
+    .side-box .cd-commentLayersContainer {
+      background: initial !important;
+    }
   }
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5c00da7e-233b-44e2-a297-25896fbef79e)
![image](https://github.com/user-attachments/assets/8a471147-377e-4bdb-9be8-c694e1021a19)
![image](https://github.com/user-attachments/assets/c95b220d-7432-44ec-9682-350dbca290c2)

Please ignore the "random bold text" in my screenshots; that's an extension called Bionic Reading.