### PR TITLE
feat(urls): Use mw-namespace configuration file for zhwiki

### DIFF
--- a/config/urls.json
+++ b/config/urls.json
@@ -13,5 +13,5 @@
 	"ru.wikisource.org": "https://ru.wikisource.org/w/load.php?modules=ext.gadget.convenientDiscussions&only=scripts",
 	"uk.wikipedia.org": "https://uk.wikipedia.org/w/index.php?title=%D0%9A%D0%BE%D1%80%D0%B8%D1%81%D1%82%D1%83%D0%B2%D0%B0%D1%87:MonAx/convenientDiscussions.js&action=raw&ctype=text/javascript",
 	"www.mediawiki.org": "https://www.mediawiki.org/w/index.php?title=User:Jack_who_built_the_house/convenientDiscussions-mwConfig.js&action=raw&ctype=text/javascript",
-	"zh.wikipedia.org": "https://zh.wikipedia.org/w/index.php?title=User:BlackShadowG/convenientDiscussions.js&action=raw&ctype=text/javascript"
+	"zh.wikipedia.org": "https://zh.wikipedia.org/w/load.php?modules=ext.gadget.convenientDiscussions&only=scripts"
 }


### PR DESCRIPTION
Loads ext.gadget.convenientDiscussions on zh.wikipedia.org.

Bug: T409653